### PR TITLE
add cast(noSideEffect) to debugPrint

### DIFF
--- a/src/print.nim
+++ b/src/print.nim
@@ -379,7 +379,7 @@ macro print*(n: varargs[untyped]): untyped =
   return s
 
 template debugPrint*(n: varargs[untyped]): untyped =
-  {.cast(gcSafe).}:
+  {.cast(gcSafe), cast(noSideEffect).}:
     print(n)
 
 type TableStyle* = enum


### PR DESCRIPTION
Regarding #15 I think it's as simple as this.

gcSafe is for using print in threads while noSideEffects for using it in funcs.