### PR TITLE
Explicitly call `items` for HashSets.

### DIFF
--- a/src/print.nim
+++ b/src/print.nim
@@ -155,7 +155,7 @@ proc newNode*[K, V](x: Table[K, V]): Node =
 
 proc newNode*[T](x: HashSet[T] | set[T]): Node =
   var nodes: seq[Node]
-  for e in x:
+  for e in x.items():
     nodes.add(newNodeFromBaseType(e))
   Node(kind: nkArray, nodes:nodes)
 


### PR DESCRIPTION
Presently, calling `print` on an object that has a `HashSet` somewhere in the graph only works if the calling module has imported `sets`, due to https://github.com/nim-lang/Nim/issues/18150. It seems that implicit `items` and `pairs` iterators in generic procs and templates are resolved in the caller's module, rather than where they're actually used.

This makes the call to `items` explicit, avoiding the issue.