### PR TITLE
disables escape \ with defined "multibyte"

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,5 +110,5 @@ By default print will display non-ascii characters with their bytes, useful for 
 ```
 However this can be disabled by using -d:multibyte
 ```nim
-("��� Page not found     ", 404)=("��� Page not found     ", 404)
+("��� Page not found     ", 404)=("��� Page not found     ", 404).
 ```

--- a/README.md
+++ b/README.md
@@ -102,13 +102,14 @@ print n
 ```
 ```nim
 n=Node(data: "hi", next: ...)
+```
 
 ## Character debugging!
 By default print will display non-ascii characters with their bytes, useful for debugging unexpected outputs with non printable characters: 
 ```nim
 ("��� Page not found     ", 404)=("\xef�\xbf�\xbd�\xef�\xbf�\xbd�\xef�\xbf�\xbd� Page not found     ", 404)
 ```
-However this can be disabled by using -d:multibyte
+However this can be disabled by using -d:multibyte:
 ```nim
-("��� Page not found     ", 404)=("��� Page not found     ", 404).
+("��� Page not found     ", 404)=("��� Page not found     ", 404)
 ```

--- a/README.md
+++ b/README.md
@@ -102,4 +102,13 @@ print n
 ```
 ```nim
 n=Node(data: "hi", next: ...)
+
+## Character debugging!
+By default print will display non-ascii characters with their bytes, useful for debugging unexpected outputs with non printable characters: 
+```nim
+("��� Page not found     ", 404)=("\xef�\xbf�\xbd�\xef�\xbf�\xbd�\xef�\xbf�\xbd� Page not found     ", 404)
+```
+However this can be disabled by using -d:multibyte
+```nim
+("��� Page not found     ", 404)=("��� Page not found     ", 404)
 ```

--- a/src/print.nim
+++ b/src/print.nim
@@ -79,7 +79,7 @@ proc escapeString*(v: string, q = "\""): string =
     of '\r': result.add r"\r"
     of '\t': result.add r"\t"
     else:
-      if ord(c) > 128:
+      if ord(c) > 128 and not defined(multibyte):
         result.add "\\x" & toHex(ord(c), 2).toLowerAscii()
       result.add c
   result.add q


### PR DESCRIPTION
Currently, with the inability to disable this, it makes debugging anything in languages where their character blocks do not lineup with the basic latin single byte character block.


For example:
![image](https://user-images.githubusercontent.com/54078872/202900023-fe3fdb78-733c-49b7-a537-2c946d6d9c64.png)

